### PR TITLE
Remove the 'develop' instance from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Glypoon is a word puzzle where the goal is to create as many words as possible u
 
 - https://glypoon.netlify.app
 
-### `develop`
-
-- https://develop--glypoon.netlify.app
-
 ## Table of Contents
 
 1. :notebook_with_decorative_cover: [Rules](#Rules)


### PR DESCRIPTION
It is now defunct. 